### PR TITLE
Fix cache URLs

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -11,12 +11,10 @@ from utils.file_utils import download_model
 from cog import BasePredictor, Input, Path
 
 
-
 CHECKPOINT_URLS = [
-    ("https://storage.googleapis.com/replicate-weights/DreamGaussian/sd-2-1.tar", "/src/stable-diffusion-2-1-base"),
-    ("https://storage.googleapis.com/replicate-weights/DreamGaussian/zero123-xl.tar", "/src/zero123-xl-diffusers")
+    ("https://weights.replicate.delivery/default/DreamGaussian/sd-2-1.tar", "/src/stable-diffusion-2-1-base"),
+    ("https://weights.replicate.delivery/default/DreamGaussian/zero123-xl.tar", "/src/zero123-xl-diffusers")
 ]
-
 
 def create_from_text(prompt, ref_size, elevation, iters, iters_refine, num_pts):
     try:


### PR DESCRIPTION
Hey @mareksagan! We recently updated our caching to use `weights.replicate.delivery` with is our much faster and shiny new CDN. As a side effect, direct GCS URLs won't work anymore. I've patched `dreamgaussian` live, and opening this PR with the changes so this repo is in sync with the version on Replicate.